### PR TITLE
Put the mkdir.run() autocommand into a augroup

### DIFF
--- a/lua/mkdir.lua
+++ b/lua/mkdir.lua
@@ -15,7 +15,11 @@ function M.run()
   end
 end
 
-cmd([[autocmd!]])
-cmd([[autocmd BufWritePre * lua require('mkdir').run()]])
+cmd([[
+  augroup MkdirRun
+  autocmd!
+  autocmd BufWritePre * lua require('mkdir').run()
+  augroup END
+]])
 
 return M


### PR DESCRIPTION
1. This is good practice
2. Having a stray `autocmd!` was deleting some other autocommands from the rest of my config
