### PR TITLE
Handle netrw URLs correctly

### DIFF
--- a/lua/mkdir.lua
+++ b/lua/mkdir.lua
@@ -9,6 +9,11 @@ local M = {}
 function M.run()
   local dir = fn.expand('<afile>:p:h')
 
+  -- This handles URLs using netrw. See ':help netrw-transparent' for details.
+  if dir:find('%l+://') == 1 then
+    return
+  end
+
   if fn.isdirectory(dir) == 0 then
     fn.mkdir(dir, 'p')
   end


### PR DESCRIPTION
Hi and thanks a lot for the plugin :)

I found this little issue when using it at work. I track my hours in a text file, and when we started remote work I kept the file on the workstation and just used `nvim scp://workstation/some_file`. Unfortunately this plugin tries to create the `scp:` directory like it was a normal subdirectory. So I have decided to just match the `scp://` part in the URL (and all the other protocols for correctness), which turned out to be quite easy.